### PR TITLE
fix(utils.js): 修復 localeMap 中的台灣區域錯誤

### DIFF
--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -117,7 +117,7 @@ const langMap = new Map([
 
 const localeMap = new Map([
   ['zh-cn', ['zh', 'zh-CN']],
-  ['zh-tw', ['zh-TW']],
+  ['zh-tw', ['zh-tw', 'zh-TW']],
   ['de-de', ['de-AT', 'de-CH', 'de-DE', 'de']],
   ['en-us', ['en-AU', 'en-CA', 'en-GB', 'en-NZ', 'en-US', 'en-ZA', 'en']],
   ['es-es', ['es', 'es-419']],


### PR DESCRIPTION
將 'zh-tw' 對應的值由原本的 ['zh-TW'] 更改為正確的 ['zh-tw', 'zh-TW']，以符合正確的區域設置。