### PR TITLE
Fix(utils.js): 改善 detectLocale 語言設置

### DIFF
--- a/src/main/utils.js
+++ b/src/main/utils.js
@@ -131,8 +131,8 @@ const localeMap = new Map([
   ['vi-vn', ['vi']]
 ])
 
-const detectLocale = (value) => {
-  const locale = value || app.getLocale()
+const detectLocale = () => {
+  const locale = app.getLocale()
   let result = 'zh-cn'
   for (let [key, list] of localeMap) {
     if (list.includes(locale)) {


### PR DESCRIPTION
在 utils.js 文件中，改善了 detectLocale 函式中的語言設置。
具體來說，移除了 value 參數，始終使用 app.getLocale() 方法來獲取當前用戶的語言設置，而不需要傳入參數。 這個更改能夠在躍遷池名正確的顯示簡體中文（zh-cn）和繁體中文（zh-tw）。