### PR TITLE
fix: Update utils.js for French HSR.

### DIFF
--- a/src/renderer/utils.js
+++ b/src/renderer/utils.js
@@ -1,11 +1,11 @@
 import * as IconComponents from '@element-plus/icons-vue'
 
 const weaponTypeNames = new Set([
-  '光锥', '光錐', 'Lichtkegel', 'Light Cone', 'Conos de luz', 'cônes de lumière', '光円錐', '광추', 'Cones de Luz', 'Световые конусы', 'Nón Ánh Sáng'
+  '光锥', '光錐', 'Lichtkegel', 'Light Cone', 'Conos de luz', 'cônes de lumière', '光円錐', '광추', 'Cones de Luz', 'Световые конусы', 'Nón Ánh Sáng', 'Cône de lumière'
 ])
 
 const characterTypeNames = new Set([
-  '角色', 'Figur', 'Character', 'Personajes', 'Personnages', 'Karakter', 'キャラクター', '캐릭터', 'Personagens', 'Персонажи', 'ตัวละคร', 'Nhân Vật'
+  '角色', 'Figur', 'Character', 'Personajes', 'Personnages', 'Karakter', 'キャラクター', '캐릭터', 'Personagens', 'Персонажи', 'ตัวละคร', 'Nhân Vật', 'Personnage'
 ])
 
 const isCharacter = (name) => characterTypeNames.has(name)


### PR DESCRIPTION
For some reason mihoyo renamed "cônes de lumière" to "Cône de lumière" and "Personnages" to "Personnage". This patch only includes the newer term without removing the old ones for retro-compatibility.

![PR](https://github.com/biuuu/star-rail-warp-export/assets/12218001/c68c4fe9-66bf-4d54-bcca-7bf48b052ad5)

