### PR TITLE
fix: 跃迁类型不足 4 种时导入数据会白屏

### DIFF
--- a/src/renderer/gachaDetail.js
+++ b/src/renderer/gachaDetail.js
@@ -14,7 +14,7 @@ const gachaDetail = (data) => {
   if (!data) return
   const detailMap = new Map()
   for (let key of order) {
-    if (!data.has(key)) return
+    if (!data.has(key)) continue
     let value = data.get(key)
     let detail = {
       count3: 0, count4: 0, count5: 0,


### PR DESCRIPTION
当前 UIGF 文件中应该包含了 4 类跃迁（角色活动跃迁、光锥活动跃迁、常驻跃迁、新手跃迁）数据。

从本地导入 UIGF 文件时，gachaDetail 函数会分别取出这 4 类跃迁数据，当导入的数据中不包含某一类数据时会直接 return，此时视图层 detail computed 获取到的数据为 undefined，视图将不会渲染任何数据。

before:


https://github.com/user-attachments/assets/a2805ca6-b6d5-49c8-98fc-7b43643362d9


after:


https://github.com/user-attachments/assets/44268c70-1ca1-48fa-8ee5-e641d6fea23b

