### PR TITLE
fix: dynamically select API path based on gacha type

### DIFF
--- a/src/main/getData.js
+++ b/src/main/getData.js
@@ -213,10 +213,7 @@ const getGachaLogs = async ({ name, key }, queryString) => {
   let region = ''
   let region_time_zone = ''
   let endId = '0'
-  let gachaURLPath = 'getGachaLog'
-  if (queryString.includes('gacha_type=21') || queryString.includes('gacha_type=22')) {
-    gachaURLPath = 'getLdGachaLog'
-  }
+  let gachaURLPath = ['21', '22'].includes(key) ? 'getLdGachaLog' : 'getGachaLog'
   const url = `${apiDomain}/common/gacha_record/api/${gachaURLPath}?${queryString}`
   do {
     // if (page % 10 === 0) {


### PR DESCRIPTION
修改了 `getGachaLogs` ，以下是关键区别和影响分析：

### 原代码行为
1. 根据输入的URL中是否包含`gacha_type=21`或`gacha_type=22`来决定API路径：
   ```javascript
   if (queryString.includes('gacha_type=21') || queryString.includes('gacha_type=22')) {
     gachaURLPath = 'getLdGachaLog'
   }
   ```
2. 这意味着：
   - 如果URL包含21/22类型，则所有请求都使用`getLdGachaLog`
   - 否则所有请求都使用`getGachaLog`

### 修改后行为
1. 根据当前获取的gacha_type(key)动态决定API路径：
   ```javascript
   let gachaURLPath = ['21', '22'].includes(key) ? 'getLdGachaLog' : 'getGachaLog'
   ```
2. 这意味着：
   - 每个gacha_type独立判断使用哪个API
   - 21/22类型使用`getLdGachaLog`
   - 其他类型使用`getGachaLog`

### 关键区别
1. **更精确的API选择**：原代码基于输入URL决定所有请求的API路径，修改后基于每个gacha_type单独决定
2. **兼容性更好**：无论输入URL是什么类型，都能正确处理所有gacha_type
3. **行为更合理**：21/22类型总是使用专用API，其他类型使用标准API

### 实际影响
1. 当输入URL是普通类型(如11/12/1/2)时：
   - 原代码：无法获取21/22类型数据(因为使用错误API)
   - 修改后：可以获取所有类型数据(每种类型使用正确API)

2. 当输入URL是21/22类型时：
   - 原代码：可以获取21/22类型，但其他类型可能使用错误API
   - 修改后：所有类型都能正确获取

### 为什么这样改更好
1. 解决了原代码的局限性 - 不再依赖输入URL决定所有请求行为
2. 更符合API设计 - 21/22类型确实需要特殊API
3. 保持向后兼容 - 不影响现有功能，只是扩展了兼容性

这个修改使工具能够正确处理所有情况下的所有gacha_type，而不再受输入URL类型的限制。